### PR TITLE
Телеграм локаль миддлварь

### DIFF
--- a/src/Http/Middlewares/SetLocaleTelegramRouteMiddleware.php
+++ b/src/Http/Middlewares/SetLocaleTelegramRouteMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HybridGram\Http\Middlewares;
+
+use HybridGram\Core\Middleware\TelegramRouteMiddlewareInterface;
+use HybridGram\Core\UpdateHelper;
+use Illuminate\Support\Facades\App;
+use Phptg\BotApi\Type\Update\Update;
+
+final class SetLocaleTelegramRouteMiddleware implements TelegramRouteMiddlewareInterface
+{
+    /**
+     * @param array<string>|null $supportedLocales List of supported locales. If null, any locale from Telegram will be used.
+     * @param string|null $fallbackLocale Fallback locale if user's locale is not supported or not available.
+     */
+    public function __construct(
+        private ?array $supportedLocales = null,
+        private ?string $fallbackLocale = null,
+    ) {}
+
+    public function handle(Update $update, callable $next): mixed
+    {
+        $user = UpdateHelper::getUserFromUpdate($update);
+        $locale = $user?->languageCode;
+
+        if ($locale !== null) {
+            $locale = $this->normalizeLocale($locale);
+            
+            if ($this->isLocaleSupported($locale)) {
+                App::setLocale($locale);
+            } elseif ($this->fallbackLocale !== null) {
+                App::setLocale($this->fallbackLocale);
+            }
+        } elseif ($this->fallbackLocale !== null) {
+            App::setLocale($this->fallbackLocale);
+        }
+
+        return $next($update);
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        // Telegram sends language codes like "en", "ru", "uk", "pt-br"
+        // Laravel typically uses "en", "ru", "uk", "pt_BR"
+        // We normalize hyphen to underscore for consistency
+        return str_replace('-', '_', $locale);
+    }
+
+    private function isLocaleSupported(string $locale): bool
+    {
+        if ($this->supportedLocales === null) {
+            return true;
+        }
+
+        // Check exact match
+        if (in_array($locale, $this->supportedLocales, true)) {
+            return true;
+        }
+
+        // Check base language match (e.g., "en" matches "en_US")
+        $baseLocale = explode('_', $locale)[0];
+        
+        return in_array($baseLocale, $this->supportedLocales, true);
+    }
+}

--- a/tests/Unit/SetLocaleMiddlewareTest.php
+++ b/tests/Unit/SetLocaleMiddlewareTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+use HybridGram\Http\Middlewares\SetLocaleTelegramRouteMiddleware;
+use Illuminate\Support\Facades\App;
+use Phptg\BotApi\Type\Chat;
+use Phptg\BotApi\Type\Message;
+use Phptg\BotApi\Type\Update\Update;
+use Phptg\BotApi\Type\User;
+
+beforeEach(function () {
+    $this->chat = new Chat(id: 123, type: 'private');
+});
+
+it('sets locale from user language code', function () {
+    $user = new User(id: 456, isBot: false, firstName: 'Test', languageCode: 'ru');
+    $message = new Message(
+        messageId: 1,
+        date: new \DateTimeImmutable(),
+        chat: $this->chat,
+        from: $user,
+        text: 'test message'
+    );
+    $update = new Update(updateId: 1, message: $message);
+
+    $middleware = new SetLocaleTelegramRouteMiddleware();
+    $next = fn($update) => 'processed';
+
+    $result = $middleware->handle($update, $next);
+
+    expect($result)->toBe('processed');
+    expect(App::getLocale())->toBe('ru');
+});
+
+it('normalizes hyphenated locale codes', function () {
+    $user = new User(id: 456, isBot: false, firstName: 'Test', languageCode: 'pt-br');
+    $message = new Message(
+        messageId: 1,
+        date: new \DateTimeImmutable(),
+        chat: $this->chat,
+        from: $user,
+        text: 'test message'
+    );
+    $update = new Update(updateId: 1, message: $message);
+
+    $middleware = new SetLocaleTelegramRouteMiddleware();
+    $next = fn($update) => 'processed';
+
+    $middleware->handle($update, $next);
+
+    expect(App::getLocale())->toBe('pt_br');
+});
+
+it('uses fallback locale when user has no language code', function () {
+    $user = new User(id: 456, isBot: false, firstName: 'Test');
+    $message = new Message(
+        messageId: 1,
+        date: new \DateTimeImmutable(),
+        chat: $this->chat,
+        from: $user,
+        text: 'test message'
+    );
+    $update = new Update(updateId: 1, message: $message);
+
+    $middleware = new SetLocaleTelegramRouteMiddleware(fallbackLocale: 'en');
+    $next = fn($update) => 'processed';
+
+    $middleware->handle($update, $next);
+
+    expect(App::getLocale())->toBe('en');
+});
+
+it('uses fallback locale when user locale is not supported', function () {
+    $user = new User(id: 456, isBot: false, firstName: 'Test', languageCode: 'ja');
+    $message = new Message(
+        messageId: 1,
+        date: new \DateTimeImmutable(),
+        chat: $this->chat,
+        from: $user,
+        text: 'test message'
+    );
+    $update = new Update(updateId: 1, message: $message);
+
+    $middleware = new SetLocaleTelegramRouteMiddleware(
+        supportedLocales: ['en', 'ru', 'uk'],
+        fallbackLocale: 'en'
+    );
+    $next = fn($update) => 'processed';
+
+    $middleware->handle($update, $next);
+
+    expect(App::getLocale())->toBe('en');
+});
+
+it('sets locale when it is in supported locales list', function () {
+    $user = new User(id: 456, isBot: false, firstName: 'Test', languageCode: 'uk');
+    $message = new Message(
+        messageId: 1,
+        date: new \DateTimeImmutable(),
+        chat: $this->chat,
+        from: $user,
+        text: 'test message'
+    );
+    $update = new Update(updateId: 1, message: $message);
+
+    $middleware = new SetLocaleTelegramRouteMiddleware(
+        supportedLocales: ['en', 'ru', 'uk'],
+        fallbackLocale: 'en'
+    );
+    $next = fn($update) => 'processed';
+
+    $middleware->handle($update, $next);
+
+    expect(App::getLocale())->toBe('uk');
+});
+
+it('matches base locale when full locale is not in supported list', function () {
+    $user = new User(id: 456, isBot: false, firstName: 'Test', languageCode: 'en-gb');
+    $message = new Message(
+        messageId: 1,
+        date: new \DateTimeImmutable(),
+        chat: $this->chat,
+        from: $user,
+        text: 'test message'
+    );
+    $update = new Update(updateId: 1, message: $message);
+
+    $middleware = new SetLocaleTelegramRouteMiddleware(
+        supportedLocales: ['en', 'ru'],
+        fallbackLocale: 'ru'
+    );
+    $next = fn($update) => 'processed';
+
+    $middleware->handle($update, $next);
+
+    expect(App::getLocale())->toBe('en_gb');
+});
+
+it('does not change locale when no user in update and no fallback', function () {
+    App::setLocale('de');
+
+    $message = new Message(
+        messageId: 1,
+        date: new \DateTimeImmutable(),
+        chat: $this->chat,
+        text: 'test message'
+    );
+    $update = new Update(updateId: 1, message: $message);
+
+    $middleware = new SetLocaleTelegramRouteMiddleware();
+    $next = fn($update) => 'processed';
+
+    $middleware->handle($update, $next);
+
+    expect(App::getLocale())->toBe('de');
+});
+
+it('works with callback query updates', function () {
+    $user = new User(id: 456, isBot: false, firstName: 'Test', languageCode: 'fr');
+    $message = new Message(
+        messageId: 1,
+        date: new \DateTimeImmutable(),
+        chat: $this->chat,
+        from: $user,
+        text: 'test message'
+    );
+    $callbackQuery = new \Phptg\BotApi\Type\CallbackQuery(
+        id: 'callback_123',
+        from: $user,
+        chatInstance: 'instance',
+        message: $message
+    );
+    $update = new Update(updateId: 1, callbackQuery: $callbackQuery);
+
+    $middleware = new SetLocaleTelegramRouteMiddleware();
+    $next = fn($update) => 'processed';
+
+    $middleware->handle($update, $next);
+
+    expect(App::getLocale())->toBe('fr');
+});


### PR DESCRIPTION
Add `SetLocaleTelegramRouteMiddleware` to automatically set the Laravel locale based on the Telegram user's language code.

---
<a href="https://cursor.com/background-agent?bcId=bc-1eda6dfa-aa79-4be6-9a31-188d238a5630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1eda6dfa-aa79-4be6-9a31-188d238a5630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds locale auto-detection for Telegram routes and thorough tests.
> 
> - Introduces `SetLocaleTelegramRouteMiddleware` to set `App` locale from `Update` user language
> - Normalizes hyphenated codes (e.g., `pt-br` -> `pt_br`) and checks `supportedLocales` with base-language fallback (e.g., `en-gb` -> `en`)
> - Applies `fallbackLocale` when user locale is missing/unsupported; leaves locale unchanged if no user and no fallback
> - Supports both message and callback query updates
> - Adds unit tests covering normalization, supported-locale/base-language match, fallback behavior, unchanged-locale case, and callback queries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f374305da44d53db7ad0daee6835b64fce72526. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->