### PR TITLE
Bot multilingual settings

### DIFF
--- a/src/Console/SetBotSettingsCommand.php
+++ b/src/Console/SetBotSettingsCommand.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HybridGram\Console;
+
+use HybridGram\Core\Config\BotConfig;
+use HybridGram\Core\Config\BotSettings\BotSettingsApplier;
+use HybridGram\Core\Config\BotSettings\BotSettingsRegistry;
+use HybridGram\Telegram\Sender\OutgoingDispatcherInterface;
+use HybridGram\Telegram\TelegramBotApi;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\App;
+
+/**
+ * Command to apply bot settings (description, name, commands, etc.) to Telegram.
+ *
+ * Configure settings in your service provider using BotSettingsRegistry::forBot().
+ */
+final class SetBotSettingsCommand extends Command
+{
+    protected $signature = 'hybridgram:settings:apply 
+        {--bot=main : Bot ID to apply settings for}
+        {--all : Apply settings for all registered bots}
+        {--dry-run : Show what would be applied without making API calls}';
+
+    protected $description = 'Apply bot settings (description, name, commands, etc.) to Telegram';
+
+    public function handle(): int
+    {
+        if ($this->option('all')) {
+            return $this->applyAll();
+        }
+
+        return $this->applyForBot($this->option('bot'));
+    }
+
+    private function applyForBot(string $botId): int
+    {
+        $config = BotConfig::getBotConfig($botId);
+
+        if ($config === null) {
+            $this->error("Bot config not found for bot: {$botId}");
+
+            return self::FAILURE;
+        }
+
+        $settings = BotSettingsRegistry::get($botId);
+
+        if ($settings === null) {
+            $this->warn("No settings registered for bot: {$botId}");
+            $this->line('Register settings in your service provider:');
+            $this->line('');
+            $this->line("    BotSettingsRegistry::forBot('{$botId}', function () {");
+            $this->line('        return BotSettings::create()');
+            $this->line("            ->description('Your bot description')");
+            $this->line("            ->description('Описание вашего бота', 'ru');");
+            $this->line('    });');
+
+            return self::FAILURE;
+        }
+
+        if ($settings->isEmpty()) {
+            $this->warn("Settings for bot '{$botId}' are empty.");
+
+            return self::SUCCESS;
+        }
+
+        if ($this->option('dry-run')) {
+            $this->showDryRun($botId, $settings);
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Applying settings for bot: {$botId}");
+
+        $dispatcher = App::make(OutgoingDispatcherInterface::class);
+        $api = (new TelegramBotApi($config->token, 'https://api.telegram.org', null, $dispatcher))
+            ->withBotId($botId);
+
+        $applier = new BotSettingsApplier($api);
+        $results = $applier->apply($settings);
+
+        $this->displayResults($results);
+
+        if ($applier->allSuccessful()) {
+            $this->newLine();
+            $this->info("All settings applied successfully for bot: {$botId}");
+
+            return self::SUCCESS;
+        }
+
+        $this->newLine();
+        $this->error("Some settings failed to apply for bot: {$botId}");
+
+        return self::FAILURE;
+    }
+
+    private function applyAll(): int
+    {
+        $bots = BotSettingsRegistry::registeredBots();
+
+        if (empty($bots)) {
+            $this->warn('No bots have registered settings.');
+
+            return self::FAILURE;
+        }
+
+        $this->info('Applying settings for all registered bots: '.implode(', ', $bots));
+        $this->newLine();
+
+        $hasFailures = false;
+
+        foreach ($bots as $botId) {
+            $this->line("--- Bot: {$botId} ---");
+            $result = $this->applyForBot($botId);
+
+            if ($result !== self::SUCCESS) {
+                $hasFailures = true;
+            }
+
+            $this->newLine();
+        }
+
+        return $hasFailures ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function showDryRun(string $botId, \HybridGram\Core\Config\BotSettings\BotSettings $settings): void
+    {
+        $this->info("[DRY RUN] Would apply the following settings for bot: {$botId}");
+        $this->newLine();
+
+        $descriptions = $settings->getDescriptions();
+        if (! $descriptions->isEmpty()) {
+            $this->line('<comment>Descriptions:</comment>');
+            foreach ($descriptions->all() as $langCode => $desc) {
+                $lang = $langCode ?: 'default';
+                $this->line("  [{$lang}] {$desc}");
+            }
+        }
+
+        $shortDescriptions = $settings->getShortDescriptions();
+        if (! $shortDescriptions->isEmpty()) {
+            $this->line('<comment>Short Descriptions:</comment>');
+            foreach ($shortDescriptions->all() as $langCode => $desc) {
+                $lang = $langCode ?: 'default';
+                $this->line("  [{$lang}] {$desc}");
+            }
+        }
+
+        $names = $settings->getNames();
+        if (! $names->isEmpty()) {
+            $this->line('<comment>Names:</comment>');
+            foreach ($names->all() as $langCode => $name) {
+                $lang = $langCode ?: 'default';
+                $this->line("  [{$lang}] {$name}");
+            }
+        }
+
+        if ($settings->getMenuButton() !== null) {
+            $this->line('<comment>Menu Button:</comment> '.get_class($settings->getMenuButton()));
+        }
+
+        if ($settings->getDefaultAdministratorRights() !== null) {
+            $this->line('<comment>Admin Rights (Groups):</comment> configured');
+        }
+
+        if ($settings->getDefaultAdministratorRightsForChannels() !== null) {
+            $this->line('<comment>Admin Rights (Channels):</comment> configured');
+        }
+
+        $commands = $settings->getCommands();
+        if (! empty($commands)) {
+            $this->line('<comment>Commands:</comment>');
+            foreach ($commands as $index => $cmdConfig) {
+                $scopeLabel = $cmdConfig['scope'] !== null
+                    ? class_basename($cmdConfig['scope']::class)
+                    : 'default';
+                $lang = $cmdConfig['languageCode'] ?: 'all';
+                $count = count($cmdConfig['commands']);
+                $this->line("  [{$index}] scope: {$scopeLabel}, lang: {$lang}, commands: {$count}");
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array{success: bool, error: ?string}> $results
+     */
+    private function displayResults(array $results): void
+    {
+        foreach ($results as $key => $result) {
+            if ($result['success']) {
+                $this->line("  <info>[OK]</info> {$key}");
+            } else {
+                $this->line("  <error>[FAIL]</error> {$key}: {$result['error']}");
+            }
+        }
+    }
+}

--- a/src/Core/Config/BotSettings/BotSettings.php
+++ b/src/Core/Config/BotSettings/BotSettings.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HybridGram\Core\Config\BotSettings;
+
+use Phptg\BotApi\Type\BotCommand;
+use Phptg\BotApi\Type\BotCommandScope;
+use Phptg\BotApi\Type\ChatAdministratorRights;
+use Phptg\BotApi\Type\MenuButton;
+
+/**
+ * Fluent builder for configuring Telegram bot settings with multilingual support.
+ *
+ * Usage example:
+ * ```php
+ * BotSettings::create()
+ *     ->description('Default bot description')
+ *     ->description('Описание бота', 'ru')
+ *     ->description('Bot-Beschreibung', 'de')
+ *     ->shortDescription('Short description')
+ *     ->shortDescription('Короткое описание', 'ru')
+ *     ->name('My Bot')
+ *     ->name('Мой Бот', 'ru')
+ *     ->menuButton(new MenuButtonWebApp('Open App', new WebAppInfo('https://example.com')))
+ *     ->commands([
+ *         new BotCommand('start', 'Start the bot'),
+ *         new BotCommand('help', 'Get help'),
+ *     ])
+ *     ->commands([
+ *         new BotCommand('start', 'Запустить бота'),
+ *         new BotCommand('help', 'Получить помощь'),
+ *     ], null, 'ru')
+ *     ->defaultAdministratorRights(new ChatAdministratorRights(...))
+ *     ->defaultAdministratorRightsForChannels(new ChatAdministratorRights(...));
+ * ```
+ */
+final class BotSettings
+{
+    private LocalizedString $descriptions;
+
+    private LocalizedString $shortDescriptions;
+
+    private LocalizedString $names;
+
+    private ?MenuButton $menuButton = null;
+
+    private ?ChatAdministratorRights $defaultAdminRights = null;
+
+    private ?ChatAdministratorRights $defaultAdminRightsForChannels = null;
+
+    /**
+     * @var array<int, array{commands: BotCommand[], scope: ?BotCommandScope, languageCode: ?string}>
+     */
+    private array $commands = [];
+
+    public function __construct()
+    {
+        $this->descriptions = new LocalizedString;
+        $this->shortDescriptions = new LocalizedString;
+        $this->names = new LocalizedString;
+    }
+
+    /**
+     * Create a new BotSettings instance.
+     */
+    public static function create(): self
+    {
+        return new self;
+    }
+
+    /**
+     * Set the bot description for a specific language.
+     *
+     * The description is shown in the chat with the bot if the chat is empty.
+     * Maximum 512 characters.
+     *
+     * @param string $description The description text
+     * @param string|null $languageCode ISO 639-1 language code. Null for default (all users without dedicated description).
+     *
+     * @see https://core.telegram.org/bots/api#setmydescription
+     */
+    public function description(string $description, ?string $languageCode = null): self
+    {
+        $this->descriptions->add($description, $languageCode);
+
+        return $this;
+    }
+
+    /**
+     * Set the bot short description for a specific language.
+     *
+     * The short description is shown on the bot's profile page and is sent together
+     * with the link when users share the bot. Maximum 120 characters.
+     *
+     * @param string $shortDescription The short description text
+     * @param string|null $languageCode ISO 639-1 language code. Null for default.
+     *
+     * @see https://core.telegram.org/bots/api#setmyshortdescription
+     */
+    public function shortDescription(string $shortDescription, ?string $languageCode = null): self
+    {
+        $this->shortDescriptions->add($shortDescription, $languageCode);
+
+        return $this;
+    }
+
+    /**
+     * Set the bot name for a specific language.
+     *
+     * Maximum 64 characters.
+     *
+     * @param string $name The bot name
+     * @param string|null $languageCode ISO 639-1 language code. Null for default.
+     *
+     * @see https://core.telegram.org/bots/api#setmyname
+     */
+    public function name(string $name, ?string $languageCode = null): self
+    {
+        $this->names->add($name, $languageCode);
+
+        return $this;
+    }
+
+    /**
+     * Set the default bot menu button.
+     *
+     * This button appears in private chats with the bot.
+     *
+     * @param MenuButton $menuButton The menu button configuration
+     *
+     * @see https://core.telegram.org/bots/api#setchatmenubutton
+     */
+    public function menuButton(MenuButton $menuButton): self
+    {
+        $this->menuButton = $menuButton;
+
+        return $this;
+    }
+
+    /**
+     * Set the default administrator rights for groups and supergroups.
+     *
+     * These rights will be suggested to users when adding the bot as an administrator.
+     *
+     * @param ChatAdministratorRights $rights The administrator rights
+     *
+     * @see https://core.telegram.org/bots/api#setmydefaultadministratorrights
+     */
+    public function defaultAdministratorRights(ChatAdministratorRights $rights): self
+    {
+        $this->defaultAdminRights = $rights;
+
+        return $this;
+    }
+
+    /**
+     * Set the default administrator rights for channels.
+     *
+     * These rights will be suggested to users when adding the bot as an administrator to channels.
+     *
+     * @param ChatAdministratorRights $rights The administrator rights
+     *
+     * @see https://core.telegram.org/bots/api#setmydefaultadministratorrights
+     */
+    public function defaultAdministratorRightsForChannels(ChatAdministratorRights $rights): self
+    {
+        $this->defaultAdminRightsForChannels = $rights;
+
+        return $this;
+    }
+
+    /**
+     * Set bot commands for a specific scope and language.
+     *
+     * @param BotCommand[] $commands List of bot commands
+     * @param BotCommandScope|null $scope Scope of users for which the commands are relevant
+     * @param string|null $languageCode ISO 639-1 language code. Null for all users.
+     *
+     * @see https://core.telegram.org/bots/api#setmycommands
+     */
+    public function commands(array $commands, ?BotCommandScope $scope = null, ?string $languageCode = null): self
+    {
+        $this->commands[] = [
+            'commands' => $commands,
+            'scope' => $scope,
+            'languageCode' => $languageCode,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Get all description localizations.
+     */
+    public function getDescriptions(): LocalizedString
+    {
+        return $this->descriptions;
+    }
+
+    /**
+     * Get all short description localizations.
+     */
+    public function getShortDescriptions(): LocalizedString
+    {
+        return $this->shortDescriptions;
+    }
+
+    /**
+     * Get all name localizations.
+     */
+    public function getNames(): LocalizedString
+    {
+        return $this->names;
+    }
+
+    /**
+     * Get the menu button configuration.
+     */
+    public function getMenuButton(): ?MenuButton
+    {
+        return $this->menuButton;
+    }
+
+    /**
+     * Get the default administrator rights for groups/supergroups.
+     */
+    public function getDefaultAdministratorRights(): ?ChatAdministratorRights
+    {
+        return $this->defaultAdminRights;
+    }
+
+    /**
+     * Get the default administrator rights for channels.
+     */
+    public function getDefaultAdministratorRightsForChannels(): ?ChatAdministratorRights
+    {
+        return $this->defaultAdminRightsForChannels;
+    }
+
+    /**
+     * Get all command configurations.
+     *
+     * @return array<int, array{commands: BotCommand[], scope: ?BotCommandScope, languageCode: ?string}>
+     */
+    public function getCommands(): array
+    {
+        return $this->commands;
+    }
+
+    /**
+     * Check if any settings are configured.
+     */
+    public function isEmpty(): bool
+    {
+        return $this->descriptions->isEmpty()
+            && $this->shortDescriptions->isEmpty()
+            && $this->names->isEmpty()
+            && $this->menuButton === null
+            && $this->defaultAdminRights === null
+            && $this->defaultAdminRightsForChannels === null
+            && empty($this->commands);
+    }
+}

--- a/src/Core/Config/BotSettings/BotSettingsApplier.php
+++ b/src/Core/Config/BotSettings/BotSettingsApplier.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HybridGram\Core\Config\BotSettings;
+
+use HybridGram\Telegram\TelegramBotApi;
+use Phptg\BotApi\FailResult;
+
+/**
+ * Applies BotSettings configuration to a Telegram bot via API.
+ */
+final class BotSettingsApplier
+{
+    /**
+     * Results of the last apply operation.
+     *
+     * @var array<string, array{success: bool, error: ?string}>
+     */
+    private array $results = [];
+
+    public function __construct(
+        private readonly TelegramBotApi $api,
+    ) {}
+
+    /**
+     * Apply all settings from BotSettings to the Telegram bot.
+     *
+     * @return array<string, array{success: bool, error: ?string}> Results of each operation
+     */
+    public function apply(BotSettings $settings): array
+    {
+        $this->results = [];
+
+        $this->applyDescriptions($settings);
+        $this->applyShortDescriptions($settings);
+        $this->applyNames($settings);
+        $this->applyMenuButton($settings);
+        $this->applyDefaultAdministratorRights($settings);
+        $this->applyCommands($settings);
+
+        return $this->results;
+    }
+
+    /**
+     * Apply only descriptions.
+     */
+    public function applyDescriptions(BotSettings $settings): void
+    {
+        foreach ($settings->getDescriptions()->all() as $languageCode => $description) {
+            $key = $this->makeKey('description', $languageCode);
+            $result = $this->api->setMyDescription($description, $languageCode);
+
+            $this->recordResult($key, $result);
+        }
+    }
+
+    /**
+     * Apply only short descriptions.
+     */
+    public function applyShortDescriptions(BotSettings $settings): void
+    {
+        foreach ($settings->getShortDescriptions()->all() as $languageCode => $shortDescription) {
+            $key = $this->makeKey('short_description', $languageCode);
+            $result = $this->api->setMyShortDescription($shortDescription, $languageCode);
+
+            $this->recordResult($key, $result);
+        }
+    }
+
+    /**
+     * Apply only names.
+     */
+    public function applyNames(BotSettings $settings): void
+    {
+        foreach ($settings->getNames()->all() as $languageCode => $name) {
+            $key = $this->makeKey('name', $languageCode);
+            $result = $this->api->setMyName($name, $languageCode);
+
+            $this->recordResult($key, $result);
+        }
+    }
+
+    /**
+     * Apply only the menu button.
+     */
+    public function applyMenuButton(BotSettings $settings): void
+    {
+        $menuButton = $settings->getMenuButton();
+        if ($menuButton === null) {
+            return;
+        }
+
+        $result = $this->api->setChatMenuButton(menuButton: $menuButton);
+        $this->recordResult('menu_button', $result);
+    }
+
+    /**
+     * Apply default administrator rights.
+     */
+    public function applyDefaultAdministratorRights(BotSettings $settings): void
+    {
+        $groupRights = $settings->getDefaultAdministratorRights();
+        if ($groupRights !== null) {
+            $result = $this->api->setMyDefaultAdministratorRights($groupRights, forChannels: false);
+            $this->recordResult('admin_rights_groups', $result);
+        }
+
+        $channelRights = $settings->getDefaultAdministratorRightsForChannels();
+        if ($channelRights !== null) {
+            $result = $this->api->setMyDefaultAdministratorRights($channelRights, forChannels: true);
+            $this->recordResult('admin_rights_channels', $result);
+        }
+    }
+
+    /**
+     * Apply commands.
+     */
+    public function applyCommands(BotSettings $settings): void
+    {
+        foreach ($settings->getCommands() as $index => $commandConfig) {
+            $scopeLabel = $commandConfig['scope'] !== null
+                ? $commandConfig['scope']::class
+                : 'default';
+            $key = $this->makeKey("commands[{$index}]:{$scopeLabel}", $commandConfig['languageCode']);
+
+            $result = $this->api->setMyCommands(
+                $commandConfig['commands'],
+                $commandConfig['scope'],
+                $commandConfig['languageCode'],
+            );
+
+            $this->recordResult($key, $result);
+        }
+    }
+
+    /**
+     * Get results of the last apply operation.
+     *
+     * @return array<string, array{success: bool, error: ?string}>
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    /**
+     * Check if all operations in the last apply were successful.
+     */
+    public function allSuccessful(): bool
+    {
+        foreach ($this->results as $result) {
+            if (! $result['success']) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get only failed results.
+     *
+     * @return array<string, array{success: bool, error: ?string}>
+     */
+    public function getFailures(): array
+    {
+        return array_filter($this->results, fn (array $result) => ! $result['success']);
+    }
+
+    private function makeKey(string $type, ?string $languageCode): string
+    {
+        if ($languageCode === null || $languageCode === '') {
+            return $type;
+        }
+
+        return "{$type}:{$languageCode}";
+    }
+
+    private function recordResult(string $key, FailResult|true $result): void
+    {
+        if ($result instanceof FailResult) {
+            $this->results[$key] = [
+                'success' => false,
+                'error' => $result->description ?? $result->response->body ?? 'Unknown error',
+            ];
+        } else {
+            $this->results[$key] = [
+                'success' => true,
+                'error' => null,
+            ];
+        }
+    }
+}

--- a/src/Core/Config/BotSettings/BotSettingsRegistry.php
+++ b/src/Core/Config/BotSettings/BotSettingsRegistry.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HybridGram\Core\Config\BotSettings;
+
+use Closure;
+
+/**
+ * Registry for storing and retrieving BotSettings for each bot.
+ *
+ * Usage in a service provider:
+ * ```php
+ * use HybridGram\Core\Config\BotSettings\BotSettings;
+ * use HybridGram\Core\Config\BotSettings\BotSettingsRegistry;
+ *
+ * public function boot(): void
+ * {
+ *     BotSettingsRegistry::forBot('main', function () {
+ *         return BotSettings::create()
+ *             ->description('My awesome bot')
+ *             ->description('Мой крутой бот', 'ru')
+ *             ->shortDescription('Best bot ever')
+ *             ->shortDescription('Лучший бот', 'ru');
+ *     });
+ * }
+ * ```
+ */
+final class BotSettingsRegistry
+{
+    /**
+     * @var array<string, Closure(): BotSettings>
+     */
+    private static array $settings = [];
+
+    /**
+     * Register BotSettings for a specific bot.
+     *
+     * @param string $botId The bot identifier
+     * @param Closure(): BotSettings $callback Callback that returns BotSettings instance
+     */
+    public static function forBot(string $botId, Closure $callback): void
+    {
+        self::$settings[$botId] = $callback;
+    }
+
+    /**
+     * Get BotSettings for a specific bot.
+     *
+     * @param string $botId The bot identifier
+     * @return BotSettings|null Returns null if no settings registered for this bot
+     */
+    public static function get(string $botId): ?BotSettings
+    {
+        if (! isset(self::$settings[$botId])) {
+            return null;
+        }
+
+        return (self::$settings[$botId])();
+    }
+
+    /**
+     * Check if settings are registered for a bot.
+     */
+    public static function has(string $botId): bool
+    {
+        return isset(self::$settings[$botId]);
+    }
+
+    /**
+     * Get all registered bot IDs.
+     *
+     * @return string[]
+     */
+    public static function registeredBots(): array
+    {
+        return array_keys(self::$settings);
+    }
+
+    /**
+     * Clear all registered settings.
+     * Useful for testing.
+     */
+    public static function clear(): void
+    {
+        self::$settings = [];
+    }
+
+    /**
+     * Clear settings for a specific bot.
+     */
+    public static function clearBot(string $botId): void
+    {
+        unset(self::$settings[$botId]);
+    }
+}

--- a/src/Core/Config/BotSettings/LocalizedString.php
+++ b/src/Core/Config/BotSettings/LocalizedString.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HybridGram\Core\Config\BotSettings;
+
+/**
+ * Represents a string value that can be localized for different languages.
+ */
+final class LocalizedString
+{
+    /**
+     * @var array<string|null, string> Map of language code => value. null key means default.
+     */
+    private array $values = [];
+
+    /**
+     * Add a localized value.
+     *
+     * @param string $value The string value
+     * @param string|null $languageCode ISO 639-1 language code (e.g., 'en', 'ru'). Null for default.
+     */
+    public function add(string $value, ?string $languageCode = null): self
+    {
+        $this->values[$languageCode] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the value for a specific language code.
+     */
+    public function get(?string $languageCode = null): ?string
+    {
+        return $this->values[$languageCode] ?? null;
+    }
+
+    /**
+     * Get all values with their language codes.
+     *
+     * @return array<string|null, string>
+     */
+    public function all(): array
+    {
+        return $this->values;
+    }
+
+    /**
+     * Check if any values are set.
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->values);
+    }
+
+    /**
+     * Check if a specific language code has a value.
+     */
+    public function has(?string $languageCode = null): bool
+    {
+        return isset($this->values[$languageCode]);
+    }
+}

--- a/src/Providers/TelegramServiceProvider.php
+++ b/src/Providers/TelegramServiceProvider.php
@@ -11,11 +11,12 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use HybridGram\Auth\TelegramGuard;
 use HybridGram\Auth\TelegramUserProvider;
+use HybridGram\Console\ClearOptimizationsCommand;
 use HybridGram\Console\DeleteWebhookCommand;
 use HybridGram\Console\GetWebhookInfoCommand;
-use HybridGram\Console\SetWebhookCommand;
 use HybridGram\Console\OptimizeRoutesCommand;
-use HybridGram\Console\ClearOptimizationsCommand;
+use HybridGram\Console\SetBotSettingsCommand;
+use HybridGram\Console\SetWebhookCommand;
 use HybridGram\Console\StartPollingCommand;
 use HybridGram\Console\TelegramRouteListCommand;
 use HybridGram\Core\Config\BotConfig;
@@ -49,6 +50,7 @@ final class TelegramServiceProvider extends ServiceProvider
                 ClearOptimizationsCommand::class,
                 StartPollingCommand::class,
                 TelegramRouteListCommand::class,
+                SetBotSettingsCommand::class,
             ]);
 
             $this->optimizes(

--- a/tests/Unit/BotSettings/BotSettingsRegistryTest.php
+++ b/tests/Unit/BotSettings/BotSettingsRegistryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use HybridGram\Core\Config\BotSettings\BotSettings;
+use HybridGram\Core\Config\BotSettings\BotSettingsRegistry;
+
+beforeEach(function () {
+    BotSettingsRegistry::clear();
+});
+
+afterEach(function () {
+    BotSettingsRegistry::clear();
+});
+
+it('registers and retrieves settings for bot', function () {
+    $settings = BotSettings::create()
+        ->description('Test description');
+
+    BotSettingsRegistry::forBot('main', fn () => $settings);
+
+    $retrieved = BotSettingsRegistry::get('main');
+
+    expect($retrieved)->toBeInstanceOf(BotSettings::class);
+    expect($retrieved->getDescriptions()->get())->toBe('Test description');
+});
+
+it('returns null for unregistered bot', function () {
+    expect(BotSettingsRegistry::get('nonexistent'))->toBeNull();
+});
+
+it('checks if bot has registered settings', function () {
+    BotSettingsRegistry::forBot('main', fn () => BotSettings::create());
+
+    expect(BotSettingsRegistry::has('main'))->toBeTrue();
+    expect(BotSettingsRegistry::has('other'))->toBeFalse();
+});
+
+it('lists all registered bots', function () {
+    BotSettingsRegistry::forBot('main', fn () => BotSettings::create());
+    BotSettingsRegistry::forBot('secondary', fn () => BotSettings::create());
+    BotSettingsRegistry::forBot('third', fn () => BotSettings::create());
+
+    $bots = BotSettingsRegistry::registeredBots();
+
+    expect($bots)->toContain('main');
+    expect($bots)->toContain('secondary');
+    expect($bots)->toContain('third');
+    expect($bots)->toHaveCount(3);
+});
+
+it('clears all settings', function () {
+    BotSettingsRegistry::forBot('main', fn () => BotSettings::create());
+    BotSettingsRegistry::forBot('secondary', fn () => BotSettings::create());
+
+    BotSettingsRegistry::clear();
+
+    expect(BotSettingsRegistry::has('main'))->toBeFalse();
+    expect(BotSettingsRegistry::has('secondary'))->toBeFalse();
+    expect(BotSettingsRegistry::registeredBots())->toBeEmpty();
+});
+
+it('clears settings for specific bot', function () {
+    BotSettingsRegistry::forBot('main', fn () => BotSettings::create());
+    BotSettingsRegistry::forBot('secondary', fn () => BotSettings::create());
+
+    BotSettingsRegistry::clearBot('main');
+
+    expect(BotSettingsRegistry::has('main'))->toBeFalse();
+    expect(BotSettingsRegistry::has('secondary'))->toBeTrue();
+});
+
+it('overwrites settings when registered twice', function () {
+    BotSettingsRegistry::forBot('main', fn () => BotSettings::create()->description('First'));
+    BotSettingsRegistry::forBot('main', fn () => BotSettings::create()->description('Second'));
+
+    $settings = BotSettingsRegistry::get('main');
+
+    expect($settings->getDescriptions()->get())->toBe('Second');
+});
+
+it('executes callback lazily on get', function () {
+    $callCount = 0;
+
+    BotSettingsRegistry::forBot('main', function () use (&$callCount) {
+        $callCount++;
+
+        return BotSettings::create()->description('Test');
+    });
+
+    expect($callCount)->toBe(0);
+
+    BotSettingsRegistry::get('main');
+    expect($callCount)->toBe(1);
+
+    BotSettingsRegistry::get('main');
+    expect($callCount)->toBe(2);
+});

--- a/tests/Unit/BotSettings/BotSettingsTest.php
+++ b/tests/Unit/BotSettings/BotSettingsTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+use HybridGram\Core\Config\BotSettings\BotSettings;
+use Phptg\BotApi\Type\BotCommand;
+use Phptg\BotApi\Type\BotCommandScope\BotCommandScopeAllPrivateChats;
+use Phptg\BotApi\Type\ChatAdministratorRights;
+use Phptg\BotApi\Type\MenuButton\MenuButtonCommands;
+use Phptg\BotApi\Type\MenuButton\MenuButtonDefault;
+
+it('creates empty settings', function () {
+    $settings = BotSettings::create();
+
+    expect($settings->isEmpty())->toBeTrue();
+    expect($settings->getDescriptions()->isEmpty())->toBeTrue();
+    expect($settings->getShortDescriptions()->isEmpty())->toBeTrue();
+    expect($settings->getNames()->isEmpty())->toBeTrue();
+    expect($settings->getMenuButton())->toBeNull();
+    expect($settings->getDefaultAdministratorRights())->toBeNull();
+    expect($settings->getDefaultAdministratorRightsForChannels())->toBeNull();
+    expect($settings->getCommands())->toBeEmpty();
+});
+
+it('sets description for default language', function () {
+    $settings = BotSettings::create()
+        ->description('Default description');
+
+    expect($settings->isEmpty())->toBeFalse();
+    expect($settings->getDescriptions()->get())->toBe('Default description');
+    expect($settings->getDescriptions()->get(null))->toBe('Default description');
+});
+
+it('sets description for multiple languages', function () {
+    $settings = BotSettings::create()
+        ->description('Default description')
+        ->description('Описание бота', 'ru')
+        ->description('Bot-Beschreibung', 'de');
+
+    expect($settings->getDescriptions()->get())->toBe('Default description');
+    expect($settings->getDescriptions()->get('ru'))->toBe('Описание бота');
+    expect($settings->getDescriptions()->get('de'))->toBe('Bot-Beschreibung');
+    expect($settings->getDescriptions()->get('fr'))->toBeNull();
+});
+
+it('sets short description for multiple languages', function () {
+    $settings = BotSettings::create()
+        ->shortDescription('Short desc')
+        ->shortDescription('Короткое описание', 'ru');
+
+    expect($settings->getShortDescriptions()->get())->toBe('Short desc');
+    expect($settings->getShortDescriptions()->get('ru'))->toBe('Короткое описание');
+});
+
+it('sets name for multiple languages', function () {
+    $settings = BotSettings::create()
+        ->name('My Bot')
+        ->name('Мой Бот', 'ru')
+        ->name('Mein Bot', 'de');
+
+    expect($settings->getNames()->get())->toBe('My Bot');
+    expect($settings->getNames()->get('ru'))->toBe('Мой Бот');
+    expect($settings->getNames()->get('de'))->toBe('Mein Bot');
+});
+
+it('sets menu button', function () {
+    $menuButton = new MenuButtonCommands;
+    $settings = BotSettings::create()
+        ->menuButton($menuButton);
+
+    expect($settings->getMenuButton())->toBe($menuButton);
+});
+
+it('sets default administrator rights for groups', function () {
+    $rights = new ChatAdministratorRights(
+        isAnonymous: false,
+        canManageChat: true,
+        canDeleteMessages: true,
+        canManageVideoChats: false,
+        canRestrictMembers: true,
+        canPromoteMembers: false,
+        canChangeInfo: true,
+        canInviteUsers: true,
+        canPostStories: false,
+        canEditStories: false,
+        canDeleteStories: false,
+    );
+
+    $settings = BotSettings::create()
+        ->defaultAdministratorRights($rights);
+
+    expect($settings->getDefaultAdministratorRights())->toBe($rights);
+    expect($settings->getDefaultAdministratorRightsForChannels())->toBeNull();
+});
+
+it('sets default administrator rights for channels', function () {
+    $rights = new ChatAdministratorRights(
+        isAnonymous: false,
+        canManageChat: true,
+        canDeleteMessages: true,
+        canManageVideoChats: false,
+        canRestrictMembers: false,
+        canPromoteMembers: false,
+        canChangeInfo: true,
+        canInviteUsers: true,
+        canPostStories: true,
+        canEditStories: true,
+        canDeleteStories: true,
+    );
+
+    $settings = BotSettings::create()
+        ->defaultAdministratorRightsForChannels($rights);
+
+    expect($settings->getDefaultAdministratorRights())->toBeNull();
+    expect($settings->getDefaultAdministratorRightsForChannels())->toBe($rights);
+});
+
+it('sets commands with scope and language', function () {
+    $commands = [
+        new BotCommand('start', 'Start the bot'),
+        new BotCommand('help', 'Get help'),
+    ];
+    $commandsRu = [
+        new BotCommand('start', 'Запустить бота'),
+        new BotCommand('help', 'Получить помощь'),
+    ];
+    $scope = new BotCommandScopeAllPrivateChats;
+
+    $settings = BotSettings::create()
+        ->commands($commands)
+        ->commands($commandsRu, null, 'ru')
+        ->commands($commands, $scope);
+
+    $allCommands = $settings->getCommands();
+    expect($allCommands)->toHaveCount(3);
+
+    expect($allCommands[0]['commands'])->toBe($commands);
+    expect($allCommands[0]['scope'])->toBeNull();
+    expect($allCommands[0]['languageCode'])->toBeNull();
+
+    expect($allCommands[1]['commands'])->toBe($commandsRu);
+    expect($allCommands[1]['scope'])->toBeNull();
+    expect($allCommands[1]['languageCode'])->toBe('ru');
+
+    expect($allCommands[2]['commands'])->toBe($commands);
+    expect($allCommands[2]['scope'])->toBe($scope);
+    expect($allCommands[2]['languageCode'])->toBeNull();
+});
+
+it('supports fluent chaining for all settings', function () {
+    $menuButton = new MenuButtonDefault;
+    $groupRights = new ChatAdministratorRights(
+        isAnonymous: false,
+        canManageChat: true,
+        canDeleteMessages: true,
+        canManageVideoChats: false,
+        canRestrictMembers: true,
+        canPromoteMembers: false,
+        canChangeInfo: true,
+        canInviteUsers: true,
+        canPostStories: false,
+        canEditStories: false,
+        canDeleteStories: false,
+    );
+    $channelRights = new ChatAdministratorRights(
+        isAnonymous: false,
+        canManageChat: true,
+        canDeleteMessages: true,
+        canManageVideoChats: false,
+        canRestrictMembers: false,
+        canPromoteMembers: false,
+        canChangeInfo: true,
+        canInviteUsers: true,
+        canPostStories: true,
+        canEditStories: true,
+        canDeleteStories: true,
+    );
+    $commands = [new BotCommand('start', 'Start')];
+
+    $settings = BotSettings::create()
+        ->description('Default description')
+        ->description('Описание', 'ru')
+        ->shortDescription('Short')
+        ->shortDescription('Короткое', 'ru')
+        ->name('Bot')
+        ->name('Бот', 'ru')
+        ->menuButton($menuButton)
+        ->defaultAdministratorRights($groupRights)
+        ->defaultAdministratorRightsForChannels($channelRights)
+        ->commands($commands)
+        ->commands($commands, null, 'ru');
+
+    expect($settings->isEmpty())->toBeFalse();
+    expect($settings->getDescriptions()->all())->toHaveCount(2);
+    expect($settings->getShortDescriptions()->all())->toHaveCount(2);
+    expect($settings->getNames()->all())->toHaveCount(2);
+    expect($settings->getMenuButton())->toBe($menuButton);
+    expect($settings->getDefaultAdministratorRights())->toBe($groupRights);
+    expect($settings->getDefaultAdministratorRightsForChannels())->toBe($channelRights);
+    expect($settings->getCommands())->toHaveCount(2);
+});

--- a/tests/Unit/BotSettings/LocalizedStringTest.php
+++ b/tests/Unit/BotSettings/LocalizedStringTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use HybridGram\Core\Config\BotSettings\LocalizedString;
+
+it('creates empty localized string', function () {
+    $localized = new LocalizedString;
+
+    expect($localized->isEmpty())->toBeTrue();
+    expect($localized->all())->toBeEmpty();
+});
+
+it('adds and retrieves default value', function () {
+    $localized = new LocalizedString;
+    $localized->add('Default value');
+
+    expect($localized->isEmpty())->toBeFalse();
+    expect($localized->get())->toBe('Default value');
+    expect($localized->get(null))->toBe('Default value');
+    expect($localized->has())->toBeTrue();
+    expect($localized->has(null))->toBeTrue();
+});
+
+it('adds and retrieves language-specific values', function () {
+    $localized = new LocalizedString;
+    $localized
+        ->add('English text', 'en')
+        ->add('Текст на русском', 'ru')
+        ->add('Deutscher Text', 'de');
+
+    expect($localized->get('en'))->toBe('English text');
+    expect($localized->get('ru'))->toBe('Текст на русском');
+    expect($localized->get('de'))->toBe('Deutscher Text');
+    expect($localized->get('fr'))->toBeNull();
+
+    expect($localized->has('en'))->toBeTrue();
+    expect($localized->has('ru'))->toBeTrue();
+    expect($localized->has('fr'))->toBeFalse();
+});
+
+it('retrieves all values', function () {
+    $localized = new LocalizedString;
+    $localized
+        ->add('Default', null)
+        ->add('English', 'en')
+        ->add('Russian', 'ru');
+
+    $all = $localized->all();
+
+    expect($all)->toHaveCount(3);
+    expect($all[null])->toBe('Default');
+    expect($all['en'])->toBe('English');
+    expect($all['ru'])->toBe('Russian');
+});
+
+it('overwrites existing value for same language code', function () {
+    $localized = new LocalizedString;
+    $localized
+        ->add('First value', 'en')
+        ->add('Second value', 'en');
+
+    expect($localized->get('en'))->toBe('Second value');
+    expect($localized->all())->toHaveCount(1);
+});
+
+it('supports fluent chaining', function () {
+    $localized = (new LocalizedString)
+        ->add('Default')
+        ->add('English', 'en')
+        ->add('Russian', 'ru');
+
+    expect($localized)->toBeInstanceOf(LocalizedString::class);
+    expect($localized->all())->toHaveCount(3);
+});


### PR DESCRIPTION
Add a fluent API and console command for configuring multilingual Telegram bot settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d0f845b-c684-4655-81a3-f7c962ee811e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d0f845b-c684-4655-81a3-f7c962ee811e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a complete pipeline to define and apply multilingual Telegram bot settings.
> 
> - New `BotSettings` fluent builder supports localized `description`, `shortDescription`, `name`, `menuButton`, default admin rights (groups/channels), and scoped/language `commands`
> - `BotSettingsRegistry` to register per-bot settings via callbacks; helpers to query/clear and list registered bots
> - `BotSettingsApplier` applies settings via `TelegramBotApi` and aggregates per-operation results
> - Console command `hybridgram:settings:apply` with `--bot`, `--all`, and `--dry-run`; prints detailed outcomes; integrated into `TelegramServiceProvider`
> - Unit tests for `BotSettings`, `LocalizedString`, and `BotSettingsRegistry`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1f6c067757af3d5fcb172d059683fdbdb17c756. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->